### PR TITLE
Avl trees

### DIFF
--- a/Data/BinaryTree.juvix
+++ b/Data/BinaryTree.juvix
@@ -1,0 +1,38 @@
+module Data.BinaryTree;
+
+open import Stdlib.Prelude hiding {length};
+open import Data.Showing;
+
+type BinaryTree (A : Type) :=
+  | leaf : BinaryTree A
+  | node : BinaryTree A -> A -> BinaryTree A -> BinaryTree A;
+
+-- fold a tree in depth first order
+fold :
+  {A B : Type}
+    -> (A -> B -> B -> B)
+    -> B
+    -> BinaryTree A
+    -> B;
+fold {A} {B} f acc :=
+  let
+    go : B -> BinaryTree A -> B;
+    go acc leaf := acc;
+    go acc (node l a r) := f a (go acc l) (go acc r);
+  in go acc;
+
+length : {A : Type} -> BinaryTree A -> Nat;
+length :=
+  fold
+    λ {
+      | _ l r := 1 + l + r
+    }
+    0;
+
+to-list : {A : Type} -> BinaryTree A -> List A;
+to-list :=
+  fold
+    λ {
+      | e ls rs := e :: ls ++ rs
+    }
+    nil;

--- a/Data/BinaryTree.juvix
+++ b/Data/BinaryTree.juvix
@@ -1,7 +1,7 @@
 module Data.BinaryTree;
 
 open import Stdlib.Prelude hiding {length};
-open import Data.Showing;
+open import Data.Show;
 
 type BinaryTree (A : Type) :=
   | leaf : BinaryTree A

--- a/Data/Map.juvix
+++ b/Data/Map.juvix
@@ -7,7 +7,7 @@ open Ord using {Ord;ord};
 
 import Stdlib.Data.Nat.Ord as Nat;
 import Data.Set as Set;
-import Data.Tree as Tree;
+import Data.BinaryTree as Tree;
 import Stdlib.Data.Ord as Ord;
 import Data.Eq as Eq;
 

--- a/Data/Set.juvix
+++ b/Data/Set.juvix
@@ -11,7 +11,7 @@ open import Test.JuvixUnit;
 import Stdlib.Data.Nat.Ord as Nat;
 import Stdlib.Data.Ord as Ord;
 
-import Data.Tree as Tree;
+import Data.BinaryTree as Tree;
 open Tree using {BinaryTree;binaryTree;leaf;node};
 
 type UnbalancedSet (A : Type) :=

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -60,7 +60,10 @@ balanceFactor : {A : Type} -> AVLTree A -> BalanceFactor;
 balanceFactor n :=
   let
     diff : Int := diffFactor n;
-  in if (0 Int.< diff) LeanRight (if (diff Int.< 0) LeanLeft LeanNone);
+  in if
+    (0 Int.< diff)
+    LeanRight
+    (if (diff Int.< 0) LeanLeft LeanNone);
 
 --- Helper function for creating a node.
 mknode :
@@ -80,6 +83,7 @@ rotateRight (node z _ (node y _ x t3) t4) :=
   mknode y x (mknode z t3 t4);
 rotateRight n := n;
 
+--- 𝒪(1). Applies local rotations if needed.
 balance : {a : Type} -> AVLTree a -> AVLTree a;
 balance empty := empty;
 balance n@(node x h l r) :=
@@ -96,17 +100,7 @@ balance n@(node x h l r) :=
         | _ := rotateRight n)
     | LeanNone := n;
 
-printNatListLn : List Nat → IO;
-printNatListLn nil := printStringLn "nil";
-printNatListLn (x :: xs) :=
-  printNat x >> printString " :: " >> printNatListLn xs;
-
---- Absolute value
-abs : Int -> Nat;
-abs (ofNat n) := n;
-abs (negSuc n) := suc n;
-
---- 𝒪(log 𝓃). Inserts an element into the tree.
+--- 𝒪(log 𝓃). Inserts an element into and ;AVLTree;.
 insert : {a : Type} -> Ord a -> a -> AVLTree a -> AVLTree a;
 insert {a} (ord cmp) x :=
   let
@@ -119,6 +113,36 @@ insert {a} (ord cmp) x :=
         | EQ := m;
   in go;
 
+--- 𝒪(log 𝓃). Removes an element from an ;AVLTree;.
+delete : {a : Type} -> Ord a -> a -> AVLTree a -> AVLTree a;
+delete {a} (ord cmp) x :=
+  let
+    deleteMin : AVLTree a -> Maybe (a × AVLTree a);
+    deleteMin empty := nothing;
+    deleteMin (node v _ l r) :=
+      case deleteMin l
+        | nothing := just (v, r)
+        | just (m, l') := just (m, mknode v l' r);
+    go : AVLTree a -> AVLTree a;
+    go empty := empty;
+    go (node y h l r) :=
+      case cmp x y
+        | LT := balance (mknode y (go l) r)
+        | GT := balance (mknode y l (go r))
+        | EQ :=
+          case l, r
+            | _, empty := l
+            | empty, _ := r
+            | _ :=
+              let
+                minRightMay : Maybe (a × AVLTree a) := deleteMin r;
+              in case minRightMay
+                | nothing := l
+                | just (minRight, r') := balance (mknode minRight l r');
+  in go;
+
+--- 𝒪(𝓃). Checks the ;AVLTree; height invariant. I.e. that
+--- every two children do not differ on height by more than 1.
 isBalanced : {a : Type} -> AVLTree a -> Bool;
 isBalanced empty := true;
 isBalanced n@(node _ _ l r) :=
@@ -143,6 +167,7 @@ toList : {a : Type} -> AVLTree a -> List a;
 toList empty := nil;
 toList (node x _ l r) := toList l ++ (x :: nil) ++ toList r;
 
+--- 𝒪(𝓃). Formats the tree in a debug friendly format.
 toStringDebug :
   {a : Type} -> Showing a -> AVLTree a -> String;
 toStringDebug {a} (showing show) :=
@@ -207,6 +232,12 @@ s2 :=
       nat-ordering
       (1 :: 3 :: 0 :: 4 :: 4 :: 8 :: 2 :: nil);
 
+s2-delete : TestDescr;
+s2-delete :=
+  case s2
+    | t, l, s :=
+      t ++str "-delete", sub l 1, delete nat-ordering 1 s;
+
 s3 : TestDescr;
 s3 :=
   "s3"
@@ -220,10 +251,14 @@ s4 :=
     , fromList nat-ordering (1 :: 2 :: 3 :: 4 :: 5 :: nil);
 
 tests : List Test;
-tests := concatMap mkTests (s1 :: s2 :: s3 :: s4 :: nil);
+tests :=
+  concatMap
+    mkTests
+    (s1 :: s2 :: s3 :: s4 :: s2-delete :: nil);
 
 main : IO;
 main :=
   runTestSuite (testSuite "AVL Set" tests)
     >> printStringLn (toStringDebug natShowing (snd (snd s2)))
-    >> printStringLn (toString natShowing (snd (snd s2)));
+    >> printStringLn
+      (toString natShowing (snd (snd s2-delete)));

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -9,6 +9,7 @@
 module Data.Set.AVL;
 
 open import Stdlib.Prelude;
+open import Data.Tmp;
 
 import Stdlib.Data.Int as Int;
 import Stdlib.Data.Int.Ord as Int;
@@ -16,12 +17,6 @@ import Stdlib.Data.Int.Ord as Int;
 import Data.Eq as Eq;
 import Data.Ord as Ord;
 import Data.Show as Show;
-
-open import Data.Tmp;
-open import Stdlib.Data.Ord;
-
-open import Data.Ord using {Ord;ord};
-open import Data.Show using {Show;show};
 
 import Data.Tree as Tree;
 open Tree using {Tree;Forest};

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -16,7 +16,9 @@ import Stdlib.Data.Int.Ord as Int;
 
 import Data.Eq as Eq;
 import Data.Ord as Ord;
+
 open import Stdlib.Data.Ord;
+
 import Data.Show as Show;
 
 import Data.Tree as Tree;
@@ -145,9 +147,7 @@ delete {a} (ord cmp) x :=
             | _, empty := l
             | empty, _ := r
             | _ :=
-              let
-                minRightMay : Maybe (a × AVLTree a) := deleteMin r;
-              in case minRightMay
+              case deleteMin r
                 | nothing := l
                 | just (minRight, r') := balance (mknode minRight l r');
   in go;

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -13,13 +13,15 @@ open import Stdlib.Prelude;
 import Stdlib.Data.Int as Int;
 import Stdlib.Data.Int.Ord as Int;
 
-open import Data.Eq;
+import Data.Eq as Eq;
+import Data.Ord as Ord;
+import Data.Show as Show;
 
-open import Data.Showing;
 open import Data.Tmp;
 open import Stdlib.Data.Ord;
 
-open import Data.Ord;
+open import Data.Ord using {Ord;ord};
+open import Data.Show using {Show;show};
 
 import Data.Tree as Tree;
 open Tree using {Tree;Forest};
@@ -192,9 +194,8 @@ toList empty := nil;
 toList (node x _ l r) := toList l ++ (x :: nil) ++ toList r;
 
 --- 𝒪(𝓃). Formats the tree in a debug friendly format.
-toStringDebug :
-  {a : Type} -> Showing a -> AVLTree a -> String;
-toStringDebug {a} (showing show) :=
+toStringDebug : {a : Type} -> Show a -> AVLTree a -> String;
+toStringDebug {a} (show fshow) :=
   let
     go : AVLTree a -> String;
     go empty := "_";
@@ -204,7 +205,7 @@ toStringDebug {a} (showing show) :=
         ++str " h"
         ++str Int.intToString (diffFactor n)
         ++str " "
-        ++str show v
+        ++str fshow v
         ++str " "
         ++str go r
         ++str ")";
@@ -218,11 +219,11 @@ toTree (node v _ l r) :=
     (Tree.node v (catMaybes (toTree l :: toTree r :: nil)));
 
 --- Returns the textual representation of an ;AVLTree;.
-toString : {a : Type} -> Showing a -> AVLTree a -> String;
+toString : {a : Type} -> Show a -> AVLTree a -> String;
 toString s := maybe "empty" (Tree.treeToString s) ∘ toTree;
 
-avlShowing : {a : Type} -> Showing a -> Showing (AVLTree a);
-avlShowing := showing ∘ toString;
+avlShowing : {a : Type} -> Show a -> Show (AVLTree a);
+avlShowing := show ∘ toString;
 
 --- Test for size and balance.
 mkTests : String × Nat × AVLTree Nat -> List Test;
@@ -234,7 +235,7 @@ mkTests (title, len, s) :=
     balanceMsg : String := "not balanced";
   in testCase
       (mkTitle "size")
-      (assertEqual nat-eq sizeMsg (size s) len)
+      (assertEqual Eq.nat sizeMsg (size s) len)
     :: testCase
       (mkTitle "balanced")
       (assertTrue balanceMsg (isBalanced s))
@@ -247,15 +248,13 @@ s1 : TestDescr;
 s1 :=
   "s1"
     , 5
-    , fromList nat-ordering (1 :: 2 :: 8 :: 3 :: 3 :: 2 :: nil);
+    , fromList Ord.nat (1 :: 2 :: 8 :: 3 :: 3 :: 2 :: nil);
 
 s2 : TestDescr;
 s2 :=
   "s2"
     , 6
-    , fromList
-      nat-ordering
-      (1 :: 3 :: 0 :: 4 :: 4 :: 8 :: 2 :: nil);
+    , fromList Ord.nat (1 :: 3 :: 0 :: 4 :: 4 :: 8 :: 2 :: nil);
 
 s2-delete : TestDescr;
 s2-delete :=
@@ -263,19 +262,17 @@ s2-delete :=
     | t, l, s :=
       t ++str "-delete"
         , sub l 2
-        , deleteMany nat-ordering (1 :: 8 :: nil) s;
+        , deleteMany Ord.nat (1 :: 8 :: nil) s;
 
 s3 : TestDescr;
 s3 :=
   "s3"
     , 6
-    , fromList nat-ordering (5 :: 4 :: 3 :: 2 :: 1 :: 0 :: nil);
+    , fromList Ord.nat (5 :: 4 :: 3 :: 2 :: 1 :: 0 :: nil);
 
 s4 : TestDescr;
 s4 :=
-  "s4"
-    , 5
-    , fromList nat-ordering (1 :: 2 :: 3 :: 4 :: 5 :: nil);
+  "s4", 5, fromList Ord.nat (1 :: 2 :: 3 :: 4 :: 5 :: nil);
 
 tests : List Test;
 tests :=
@@ -286,6 +283,5 @@ tests :=
 main : IO;
 main :=
   runTestSuite (testSuite "AVL Set" tests)
-    >> printStringLn (toStringDebug natShowing (snd (snd s3)))
-    >> printStringLn
-      (toString natShowing (snd (snd s2-delete)));
+    >> printStringLn (toStringDebug Show.nat (snd (snd s3)))
+    >> printStringLn (toString Show.nat (snd (snd s2-delete)));

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -100,6 +100,19 @@ balance n@(node x h l r) :=
         | _ := rotateRight n)
     | LeanNone := n;
 
+--- 𝒪(log 𝓃). Queries whether an element is in an ;AVLTree;.
+member? : {a : Type} -> Ord a -> a -> AVLTree a -> Bool;
+member? {a} (ord cmp) x :=
+  let
+    go : AVLTree a -> Bool;
+    go empty := false;
+    go m@(node y h l r) :=
+      case cmp x y
+        | LT := go l
+        | GT := go r
+        | EQ := true;
+  in go;
+
 --- 𝒪(log 𝓃). Inserts an element into and ;AVLTree;.
 insert : {a : Type} -> Ord a -> a -> AVLTree a -> AVLTree a;
 insert {a} (ord cmp) x :=

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -143,9 +143,8 @@ delete {a} (ord cmp) x :=
         | LT := balance (mknode y (go l) r)
         | GT := balance (mknode y l (go r))
         | EQ :=
-          case l, r
-            | _, empty := l
-            | empty, _ := r
+          case l
+            | empty := r
             | _ :=
               case deleteMin r
                 | nothing := l

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -244,7 +244,7 @@ s1 : TestDescr;
 s1 :=
   "s1"
     , 5
-    , fromList Ord.nat (1 :: 2 :: 8 :: 3 :: 3 :: 2 :: nil);
+    , fromList Ord.nat (1 :: 2 :: 8 :: 3 :: 3 :: 2 :: 9 :: nil);
 
 s2 : TestDescr;
 s2 :=

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -1,0 +1,185 @@
+--- AVL trees are a type of self-balancing binary search tree, where the heights
+--- of the left and right subtrees of every node differ by at most 1. This
+--- ensures that the height of the tree is logarithmic in the number of nodes,
+--- which guarantees efficient insertion, deletion, and search operations (all
+--- are guaranteed to run in 𝒪(log 𝓃) time).
+---
+--- This module defines an AVL tree data type and provides functions for
+--- constructing, modifying, and querying AVL trees.
+module Data.Set.AVL;
+
+open import Stdlib.Prelude;
+
+import Stdlib.Data.Int as Int;
+import Stdlib.Data.Int.Ord as Int;
+
+open import Data.Showing;
+
+open import Data.Ord;
+
+import Stdlib.Data.Nat.Ord as Nat;
+open Nat;
+open import Test.JuvixUnit;
+
+--- A self-balancing binary search tree.
+type AVLTree (A : Type) :=
+  | --- An empty AVL tree.
+    empty : AVLTree A
+  | --- An node of an AVL tree.
+    node : A -> Nat -> AVLTree A -> AVLTree A -> AVLTree A;
+
+--- 𝒪(1) Retrieves the height of an ;AVLTree;. The height is the distance from
+--- the root to the deepest child.
+height : {A : Type} -> AVLTree A -> Nat;
+height empty := 0;
+height (node _ h _ _) := h;
+
+type BalanceFactor :=
+  | Neg : BalanceFactor
+  | Zero : BalanceFactor
+  | Pos : BalanceFactor;
+
+--- 𝒪(1) Computes the balance factor, i.e., the height of the right subtree
+--- minus the height of the left subtree.
+balanceFactor : {A : Type} -> AVLTree A -> BalanceFactor;
+balanceFactor empty := Zero;
+balanceFactor (node _ _ left right) :=
+  let
+    diff : Int := Int.intSubNat (height right) (height left);
+  in if (0 Int.< diff) Pos (if (diff Int.< 0) Neg Zero);
+
+--- Helper function for creating a node.
+mknode :
+  {A : Type} -> A -> AVLTree A -> AVLTree A -> AVLTree A;
+mknode val l r := node val (max (height l) (height r)) l r;
+
+--- left-left rotation.
+rotateLeft : {A : Type} -> AVLTree A -> AVLTree A;
+rotateLeft (node x h l (node y rh rl rr)) :=
+  mknode y (mknode x l rl) rr;
+rotateLeft n := n;
+
+--- right-right rotation.
+rotateRight : {A : Type} -> AVLTree A -> AVLTree A;
+rotateRight (node x h (node y lh ll lr) r) :=
+  mknode y ll (mknode x lr r);
+rotateRight n := n;
+
+leftChild : {A : Type} -> AVLTree A -> AVLTree A;
+leftChild empty := empty;
+leftChild (node _ _ l _) := l;
+
+rightChild : {A : Type} -> AVLTree A -> AVLTree A;
+rightChild empty := empty;
+rightChild (node _ _ l r) := r;
+
+balance : {a : Type} -> AVLTree a -> AVLTree a;
+balance empty := empty;
+balance n@(node x h l r) :=
+  let
+    factor : BalanceFactor := balanceFactor n;
+  in case factor
+    | Pos :=
+      if
+        (height (rightChild r) > height (leftChild r))
+        (rotateLeft (mknode x l (rotateRight r)))
+        (rotateLeft (mknode x l r))
+    | Neg :=
+      if
+        (height (leftChild l) > height (rightChild l))
+        (rotateRight (mknode x (rotateLeft l) r))
+        (rotateRight (mknode x l r))
+    | Zero := n;
+
+printNatListLn : List Nat → IO;
+printNatListLn nil := printStringLn "nil";
+printNatListLn (x :: xs) :=
+  printNat x >> printString " :: " >> printNatListLn xs;
+
+--- Absolute value
+abs : Int -> Nat;
+abs (ofNat n) := n;
+abs (negSuc n) := suc n;
+
+--- 𝒪(log 𝓃). Inserts an element into the tree.
+insert : {a : Type} -> Ord a -> a -> AVLTree a -> AVLTree a;
+insert {a} (ord cmp) x :=
+  let
+    go : AVLTree a -> AVLTree a;
+    go empty := mknode x empty empty;
+    go m@(node y h l r) :=
+      case cmp x y
+        | LT := balance (mknode y (go l) r)
+        | GT := balance (mknode y l (go r))
+        | EQ := m;
+  in go;
+
+isBalanced : {a : Type} -> AVLTree a -> Bool;
+isBalanced empty := true;
+isBalanced (node _ _ l r) :=
+  isBalanced l
+    && isBalanced r
+    && abs (Int.intSubNat (height l) (height r)) <= 1;
+
+--- 𝒪(𝓃 log 𝓃). Create an ;AVLTree; from an unsorted ;List;.
+fromList : {a : Type} -> Ord a -> List a -> AVLTree a;
+fromList o :=
+  foldl
+    λ {
+      | acc x := insert o x acc
+    }
+    empty;
+
+--- 𝒪(𝓃). Returns the number of elements of an ;AVLTree;.
+size : {a : Type} -> AVLTree a -> Nat;
+size empty := 0;
+size (node _ _ l r) := 1 + size l + size r;
+
+--- 𝒪(𝓃). Returns the elements of an ;AVLTree; in ascending order.
+toList : {a : Type} -> AVLTree a -> List a;
+toList empty := nil;
+toList (node x _ l r) := toList l ++ (x :: nil) ++ toList r;
+
+--- Returns the textual representation of an ;AVLTree;.
+toString : {a : Type} -> Showing a -> AVLTree a -> String;
+toString {a} (showing show) :=
+  let
+    go : AVLTree a -> String;
+    go empty := "_";
+    go (node v h l r) :=
+      "("
+        ++str go l
+        ++str " "
+        ++str show v
+        ++str " "
+        ++str go r
+        ++str ")";
+  in go;
+
+avlShowing : {a : Type} -> Showing a -> Showing (AVLTree a);
+avlShowing := showing ∘ toString;
+
+tests : List Test;
+tests :=
+  let
+    s1 : AVLTree Nat;
+    s1 :=
+      fromList nat-ordering (1 :: 2 :: 8 :: 3 :: 3 :: 2 :: nil);
+    s0 : AVLTree Nat;
+    s0 := fromList nat-ordering (1 :: 1 :: nil);
+  in testCase
+      "is balanced"
+      (assertTrue "not balanced" (isBalanced s1))
+    :: testCase
+      "size"
+      (assertTrue (natToString (size s1)) (size s1 Nat.== 4))
+    :: testCase
+      "size"
+      (assertTrue (natToString (size s1)) (size s1 Nat.== 4))
+    :: testCase
+      "size s0"
+      (assertTrue (toString natShowing s0) (size s0 Nat.== 1))
+    :: nil;
+
+main : IO;
+main := runTestSuite (testSuite "AVL Set" tests);

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -13,6 +13,8 @@ open import Stdlib.Prelude;
 import Stdlib.Data.Int as Int;
 import Stdlib.Data.Int.Ord as Int;
 
+open import Data.Eq;
+
 open import Data.Showing;
 open import Data.Tmp;
 open import Stdlib.Data.Ord;
@@ -78,14 +80,6 @@ rotateRight (node z _ (node y _ x t3) t4) :=
   mknode y x (mknode z t3 t4);
 rotateRight n := n;
 
-leftChild : {A : Type} -> AVLTree A -> AVLTree A;
-leftChild empty := empty;
-leftChild (node _ _ l _) := l;
-
-rightChild : {A : Type} -> AVLTree A -> AVLTree A;
-rightChild empty := empty;
-rightChild (node _ _ l r) := r;
-
 balance : {a : Type} -> AVLTree a -> AVLTree a;
 balance empty := empty;
 balance n@(node x h l r) :=
@@ -149,8 +143,9 @@ toList : {a : Type} -> AVLTree a -> List a;
 toList empty := nil;
 toList (node x _ l r) := toList l ++ (x :: nil) ++ toList r;
 
-toString2 : {a : Type} -> Showing a -> AVLTree a -> String;
-toString2 {a} (showing show) :=
+toStringDebug :
+  {a : Type} -> Showing a -> AVLTree a -> String;
+toStringDebug {a} (showing show) :=
   let
     go : AVLTree a -> String;
     go empty := "_";
@@ -177,39 +172,58 @@ toString : {a : Type} -> Showing a -> AVLTree a -> String;
 toString s := maybe "empty" (Tree.treeToString s) ∘ toTree;
 
 avlShowing : {a : Type} -> Showing a -> Showing (AVLTree a);
-avlShowing := showing ∘ toString2;
+avlShowing := showing ∘ toString;
 
-s2 : AVLTree Nat;
-s2 := fromList nat-ordering (1 :: 3 :: 0 :: 4 :: 4 :: 8 :: 2 :: nil);
+--- Test for size and balance.
+mkTests : String × Nat × AVLTree Nat -> List Test;
+mkTests (title, len, s) :=
+  let
+    mkTitle : String -> String;
+    mkTitle m := title ++str " " ++str m;
+    sizeMsg : String := "sizes do not match";
+    balanceMsg : String := "not balanced";
+  in testCase
+      (mkTitle "size")
+      (assertEqual nat-eq sizeMsg (size s) len)
+    :: testCase
+      (mkTitle "balanced")
+      (assertTrue balanceMsg (isBalanced s))
+    :: nil;
+
+TestDescr : Type;
+TestDescr := String × Nat × AVLTree Nat;
+
+s1 : TestDescr;
+s1 :=
+  "s1"
+    , 5
+    , fromList nat-ordering (1 :: 2 :: 8 :: 3 :: 3 :: 2 :: nil);
+
+s2 : TestDescr;
+s2 :=
+  "s2"
+    , 6
+    , fromList
+      nat-ordering
+      (1 :: 3 :: 0 :: 4 :: 4 :: 8 :: 2 :: nil);
+
+s3 : TestDescr;
+s3 :=
+  "s3"
+    , 6
+    , fromList nat-ordering (5 :: 4 :: 3 :: 2 :: 1 :: 0 :: nil);
+
+s4 : TestDescr;
+s4 :=
+  "s4"
+    , 5
+    , fromList nat-ordering (1 :: 2 :: 3 :: 4 :: 5 :: nil);
 
 tests : List Test;
-tests :=
-  let
-    s0 : AVLTree Nat;
-    s0 := fromList nat-ordering (1 :: 1 :: nil);
-    s1 : AVLTree Nat;
-    s1 :=
-      fromList nat-ordering (1 :: 2 :: 8 :: 3 :: 3 :: 2 :: nil);
-  in testCase
-      "is balanced s1"
-      (assertTrue "not balanced" (isBalanced s1))
-    :: testCase
-      "size s1"
-      (assertTrue (natToString (size s1)) (size s1 Nat.== 4))
-    :: testCase
-      "size s0"
-      (assertTrue (toString natShowing s0) (size s0 Nat.== 1))
-    :: testCase
-      "size s2"
-      (assertTrue (toString natShowing s2) (size s2 Nat.== 6))
-    :: testCase
-      "balanced s2"
-      (assertTrue "not balanced" (isBalanced s2))
-    :: nil;
+tests := concatMap mkTests (s1 :: s2 :: s3 :: s4 :: nil);
 
 main : IO;
 main :=
   runTestSuite (testSuite "AVL Set" tests)
-    >> printStringLn (toString2 natShowing s2)
-    >> printStringLn (toString natShowing s2)
-    ;
+    >> printStringLn (toStringDebug natShowing (snd (snd s2)))
+    >> printStringLn (toString natShowing (snd (snd s2)));

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -14,8 +14,13 @@ import Stdlib.Data.Int as Int;
 import Stdlib.Data.Int.Ord as Int;
 
 open import Data.Showing;
+open import Data.Tmp;
+open import Stdlib.Data.Ord;
 
 open import Data.Ord;
+
+import Data.Tree as Tree;
+open Tree using {Tree;Forest};
 
 import Stdlib.Data.Nat.Ord as Nat;
 open Nat;
@@ -35,34 +40,42 @@ height empty := 0;
 height (node _ h _ _) := h;
 
 type BalanceFactor :=
-  | Neg : BalanceFactor
-  | Zero : BalanceFactor
-  | Pos : BalanceFactor;
+  | --- Left children is higher.
+    Neg : BalanceFactor
+  | --- Equal heights of children.
+    Zero : BalanceFactor
+  | --- Right children is higher.
+    Pos : BalanceFactor;
+
+diffFactor : {A : Type} -> AVLTree A -> Int;
+diffFactor empty := 0;
+diffFactor (node _ _ left right) :=
+  Int.intSubNat (height right) (height left);
 
 --- 𝒪(1) Computes the balance factor, i.e., the height of the right subtree
 --- minus the height of the left subtree.
 balanceFactor : {A : Type} -> AVLTree A -> BalanceFactor;
-balanceFactor empty := Zero;
-balanceFactor (node _ _ left right) :=
+balanceFactor n :=
   let
-    diff : Int := Int.intSubNat (height right) (height left);
+    diff : Int := diffFactor n;
   in if (0 Int.< diff) Pos (if (diff Int.< 0) Neg Zero);
 
 --- Helper function for creating a node.
 mknode :
   {A : Type} -> A -> AVLTree A -> AVLTree A -> AVLTree A;
-mknode val l r := node val (max (height l) (height r)) l r;
+mknode val l r :=
+  node val (1 + max (height l) (height r)) l r;
 
---- left-left rotation.
+--- Left rotation.
 rotateLeft : {A : Type} -> AVLTree A -> AVLTree A;
-rotateLeft (node x h l (node y rh rl rr)) :=
-  mknode y (mknode x l rl) rr;
+rotateLeft (node x _ a (node z _ b c)) :=
+  mknode z (mknode x a b) c;
 rotateLeft n := n;
 
---- right-right rotation.
+--- Right rotation.
 rotateRight : {A : Type} -> AVLTree A -> AVLTree A;
-rotateRight (node x h (node y lh ll lr) r) :=
-  mknode y ll (mknode x lr r);
+rotateRight (node z _ (node y _ x t3) t4) :=
+  mknode y x (mknode z t3 t4);
 rotateRight n := n;
 
 leftChild : {A : Type} -> AVLTree A -> AVLTree A;
@@ -80,15 +93,13 @@ balance n@(node x h l r) :=
     factor : BalanceFactor := balanceFactor n;
   in case factor
     | Pos :=
-      if
-        (height (rightChild r) > height (leftChild r))
-        (rotateLeft (mknode x l (rotateRight r)))
-        (rotateLeft (mknode x l r))
+      (case balanceFactor r
+        | Neg := rotateLeft (mknode x l (rotateRight r))
+        | _ := rotateLeft n)
     | Neg :=
-      if
-        (height (leftChild l) > height (rightChild l))
-        (rotateRight (mknode x (rotateLeft l) r))
-        (rotateRight (mknode x l r))
+      (case balanceFactor l
+        | Pos := rotateRight (mknode x (rotateLeft l) r)
+        | _ := rotateRight n)
     | Zero := n;
 
 printNatListLn : List Nat → IO;
@@ -116,10 +127,8 @@ insert {a} (ord cmp) x :=
 
 isBalanced : {a : Type} -> AVLTree a -> Bool;
 isBalanced empty := true;
-isBalanced (node _ _ l r) :=
-  isBalanced l
-    && isBalanced r
-    && abs (Int.intSubNat (height l) (height r)) <= 1;
+isBalanced n@(node _ _ l r) :=
+  isBalanced l && isBalanced r && abs (diffFactor n) <= 1;
 
 --- 𝒪(𝓃 log 𝓃). Create an ;AVLTree; from an unsorted ;List;.
 fromList : {a : Type} -> Ord a -> List a -> AVLTree a;
@@ -140,15 +149,16 @@ toList : {a : Type} -> AVLTree a -> List a;
 toList empty := nil;
 toList (node x _ l r) := toList l ++ (x :: nil) ++ toList r;
 
---- Returns the textual representation of an ;AVLTree;.
-toString : {a : Type} -> Showing a -> AVLTree a -> String;
-toString {a} (showing show) :=
+toString2 : {a : Type} -> Showing a -> AVLTree a -> String;
+toString2 {a} (showing show) :=
   let
     go : AVLTree a -> String;
     go empty := "_";
-    go (node v h l r) :=
+    go n@(node v h l r) :=
       "("
         ++str go l
+        ++str " h"
+        ++str Int.intToString (diffFactor n)
         ++str " "
         ++str show v
         ++str " "
@@ -156,30 +166,50 @@ toString {a} (showing show) :=
         ++str ")";
   in go;
 
+toTree : {a : Type} -> AVLTree a -> Maybe (Tree a);
+toTree empty := nothing;
+toTree (node v _ l r) :=
+  just
+    (Tree.node v (catMaybes (toTree l :: toTree r :: nil)));
+
+--- Returns the textual representation of an ;AVLTree;.
+toString : {a : Type} -> Showing a -> AVLTree a -> String;
+toString s := maybe "empty" (Tree.treeToString s) ∘ toTree;
+
 avlShowing : {a : Type} -> Showing a -> Showing (AVLTree a);
-avlShowing := showing ∘ toString;
+avlShowing := showing ∘ toString2;
+
+s2 : AVLTree Nat;
+s2 := fromList nat-ordering (1 :: 3 :: 0 :: 4 :: 4 :: 8 :: 2 :: nil);
 
 tests : List Test;
 tests :=
   let
+    s0 : AVLTree Nat;
+    s0 := fromList nat-ordering (1 :: 1 :: nil);
     s1 : AVLTree Nat;
     s1 :=
       fromList nat-ordering (1 :: 2 :: 8 :: 3 :: 3 :: 2 :: nil);
-    s0 : AVLTree Nat;
-    s0 := fromList nat-ordering (1 :: 1 :: nil);
   in testCase
-      "is balanced"
+      "is balanced s1"
       (assertTrue "not balanced" (isBalanced s1))
     :: testCase
-      "size"
-      (assertTrue (natToString (size s1)) (size s1 Nat.== 4))
-    :: testCase
-      "size"
+      "size s1"
       (assertTrue (natToString (size s1)) (size s1 Nat.== 4))
     :: testCase
       "size s0"
       (assertTrue (toString natShowing s0) (size s0 Nat.== 1))
+    :: testCase
+      "size s2"
+      (assertTrue (toString natShowing s2) (size s2 Nat.== 6))
+    :: testCase
+      "balanced s2"
+      (assertTrue "not balanced" (isBalanced s2))
     :: nil;
 
 main : IO;
-main := runTestSuite (testSuite "AVL Set" tests);
+main :=
+  runTestSuite (testSuite "AVL Set" tests)
+    >> printStringLn (toString2 natShowing s2)
+    >> printStringLn (toString natShowing s2)
+    ;

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -16,6 +16,7 @@ import Stdlib.Data.Int.Ord as Int;
 
 import Data.Eq as Eq;
 import Data.Ord as Ord;
+open import Stdlib.Data.Ord;
 import Data.Show as Show;
 
 import Data.Tree as Tree;
@@ -277,6 +278,6 @@ tests :=
 
 main : IO;
 main :=
-  runTestSuite (testSuite "AVL Set" tests)
-    >> printStringLn (toStringDebug Show.nat (snd (snd s3)))
-    >> printStringLn (toString Show.nat (snd (snd s2-delete)));
+  printStringLn (toString Show.nat (snd (snd s1)))
+    >> printStringLn (toStringDebug Show.nat (snd (snd s1)))
+    >> runTestSuite (testSuite "AVL Set" tests);

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -141,6 +141,17 @@ delete {a} (ord cmp) x :=
                 | just (minRight, r') := balance (mknode minRight l r');
   in go;
 
+--- 𝒪(d log 𝓃). Deletes d elements from an ;AVLTree;.
+deleteMany :
+  {a : Type} -> Ord a -> List a -> AVLTree a -> AVLTree a;
+deleteMany o d t :=
+  foldl
+    λ {
+      | acc x := delete o x acc
+    }
+    t
+    d;
+
 --- 𝒪(𝓃). Checks the ;AVLTree; height invariant. I.e. that
 --- every two children do not differ on height by more than 1.
 isBalanced : {a : Type} -> AVLTree a -> Bool;
@@ -236,7 +247,9 @@ s2-delete : TestDescr;
 s2-delete :=
   case s2
     | t, l, s :=
-      t ++str "-delete", sub l 1, delete nat-ordering 1 s;
+      t ++str "-delete"
+        , sub l 2
+        , deleteMany nat-ordering (1 :: 8 :: nil) s;
 
 s3 : TestDescr;
 s3 :=

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -151,6 +151,20 @@ delete {a} (ord cmp) x :=
                 | just (minRight, r') := balance (mknode minRight l r');
   in go;
 
+--- 𝒪(log 𝓃). Returns the minimum element of the ;AVLTree;.
+lookupMin : {a : Type} -> AVLTree a -> Maybe a;
+lookupMin empty := nothing;
+lookupMin (node y _ empty empty) := just y;
+lookupMin (node _ _ empty r) := lookupMin r;
+lookupMin (node _ _ l _) := lookupMin l;
+
+--- 𝒪(log 𝓃). Returns the maximum element of the ;AVLTree;.
+lookupMax : {a : Type} -> AVLTree a -> Maybe a;
+lookupMax empty := nothing;
+lookupMax (node y _ empty empty) := just y;
+lookupMax (node _ _ l empty) := lookupMax l;
+lookupMax (node _ _ _ r) := lookupMax r;
+
 --- 𝒪(𝒹 log 𝓃). Deletes d elements from an ;AVLTree;.
 deleteMany :
   {a : Type} -> Ord a -> List a -> AVLTree a -> AVLTree a;

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -141,7 +141,7 @@ delete {a} (ord cmp) x :=
                 | just (minRight, r') := balance (mknode minRight l r');
   in go;
 
---- 𝒪(d log 𝓃). Deletes d elements from an ;AVLTree;.
+--- 𝒪(𝒹 log 𝓃). Deletes d elements from an ;AVLTree;.
 deleteMany :
   {a : Type} -> Ord a -> List a -> AVLTree a -> AVLTree a;
 deleteMany o d t :=

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -43,11 +43,11 @@ height (node _ h _ _) := h;
 
 type BalanceFactor :=
   | --- Left children is higher.
-    Neg : BalanceFactor
+    LeanLeft : BalanceFactor
   | --- Equal heights of children.
-    Zero : BalanceFactor
+    LeanNone : BalanceFactor
   | --- Right children is higher.
-    Pos : BalanceFactor;
+    LeanRight : BalanceFactor;
 
 diffFactor : {A : Type} -> AVLTree A -> Int;
 diffFactor empty := 0;
@@ -60,7 +60,7 @@ balanceFactor : {A : Type} -> AVLTree A -> BalanceFactor;
 balanceFactor n :=
   let
     diff : Int := diffFactor n;
-  in if (0 Int.< diff) Pos (if (diff Int.< 0) Neg Zero);
+  in if (0 Int.< diff) LeanRight (if (diff Int.< 0) LeanLeft LeanNone);
 
 --- Helper function for creating a node.
 mknode :
@@ -86,15 +86,15 @@ balance n@(node x h l r) :=
   let
     factor : BalanceFactor := balanceFactor n;
   in case factor
-    | Pos :=
+    | LeanRight :=
       (case balanceFactor r
-        | Neg := rotateLeft (mknode x l (rotateRight r))
+        | LeanLeft := rotateLeft (mknode x l (rotateRight r))
         | _ := rotateLeft n)
-    | Neg :=
+    | LeanLeft :=
       (case balanceFactor l
-        | Pos := rotateRight (mknode x (rotateLeft l) r)
+        | LeanRight := rotateRight (mknode x (rotateLeft l) r)
         | _ := rotateRight n)
-    | Zero := n;
+    | LeanNone := n;
 
 printNatListLn : List Nat → IO;
 printNatListLn nil := printStringLn "nil";

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -54,7 +54,7 @@ diffFactor empty := 0;
 diffFactor (node _ _ left right) :=
   Int.intSubNat (height right) (height left);
 
---- 𝒪(1) Computes the balance factor, i.e., the height of the right subtree
+--- 𝒪(1). Computes the balance factor, i.e., the height of the right subtree
 --- minus the height of the left subtree.
 balanceFactor : {A : Type} -> AVLTree A -> BalanceFactor;
 balanceFactor n :=
@@ -65,19 +65,19 @@ balanceFactor n :=
     LeanRight
     (if (diff Int.< 0) LeanLeft LeanNone);
 
---- Helper function for creating a node.
+--- 𝒪(1). Helper function for creating a node.
 mknode :
   {A : Type} -> A -> AVLTree A -> AVLTree A -> AVLTree A;
 mknode val l r :=
   node val (1 + max (height l) (height r)) l r;
 
---- Left rotation.
+--- 𝒪(1). Left rotation.
 rotateLeft : {A : Type} -> AVLTree A -> AVLTree A;
 rotateLeft (node x _ a (node z _ b c)) :=
   mknode z (mknode x a b) c;
 rotateLeft n := n;
 
---- Right rotation.
+--- 𝒪(1). Right rotation.
 rotateRight : {A : Type} -> AVLTree A -> AVLTree A;
 rotateRight (node z _ (node y _ x t3) t4) :=
   mknode y x (mknode z t3 t4);
@@ -197,6 +197,7 @@ toStringDebug {a} (showing show) :=
         ++str ")";
   in go;
 
+--- 𝒪(𝓃).
 toTree : {a : Type} -> AVLTree a -> Maybe (Tree a);
 toTree empty := nothing;
 toTree (node v _ l r) :=
@@ -272,6 +273,6 @@ tests :=
 main : IO;
 main :=
   runTestSuite (testSuite "AVL Set" tests)
-    >> printStringLn (toStringDebug natShowing (snd (snd s2)))
+    >> printStringLn (toStringDebug natShowing (snd (snd s3)))
     >> printStringLn
       (toString natShowing (snd (snd s2-delete)));

--- a/Data/Set/AVL.juvix
+++ b/Data/Set/AVL.juvix
@@ -32,7 +32,7 @@ open import Test.JuvixUnit;
 type AVLTree (A : Type) :=
   | --- An empty AVL tree.
     empty : AVLTree A
-  | --- An node of an AVL tree.
+  | --- A node of an AVL tree.
     node : A -> Nat -> AVLTree A -> AVLTree A -> AVLTree A;
 
 --- 𝒪(1) Retrieves the height of an ;AVLTree;. The height is the distance from

--- a/Data/String.juvix
+++ b/Data/String.juvix
@@ -5,4 +5,3 @@ open import Stdlib.Data.String.Ord;
 
 null? : String -> Bool;
 null? s := s == "";
-

--- a/Data/Tmp.juvix
+++ b/Data/Tmp.juvix
@@ -3,6 +3,13 @@ module Data.Tmp;
 
 open import Stdlib.Prelude;
 
+import Stdlib.Data.Int as Int;
+import Stdlib.Data.Int.Ord as Int;
+
+open import Data.Ord using {Ord;ord} public;
+open import Data.Show using {Show;show} public;
+open import Data.Eq using {Eq;eq} public;
+
 unlines : List String -> String;
 unlines nil := "";
 unlines (x :: xs) := x ++str "\n" ++str unlines xs;
@@ -28,7 +35,8 @@ catMaybes nil := nil;
 catMaybes (just h :: hs) := h :: catMaybes hs;
 catMaybes (nothing :: hs) := catMaybes hs;
 
-concatMap : {A B : Type} -> (A -> List B) -> List A -> List B;
+concatMap :
+  {A B : Type} -> (A -> List B) -> List A -> List B;
 concatMap f := flatten ∘ map f;
 
 printNatListLn : List Nat → IO;

--- a/Data/Tmp.juvix
+++ b/Data/Tmp.juvix
@@ -1,0 +1,29 @@
+--- the functions here should be eventually put in the stdlib
+module Data.Tmp;
+
+open import Stdlib.Prelude;
+
+unlines : List String -> String;
+unlines nil := "";
+unlines (x :: xs) := x ++str "\n" ++str unlines xs;
+
+zipWith :
+  {A : Type}
+    -> {B : Type}
+    -> {C : Type}
+    -> (A -> B -> C)
+    -> List A
+    -> List B
+    -> List C;
+zipWith {A} {B} {C} f as bs :=
+  let
+    go : List A -> List B -> List C -> List C;
+    go _ nil acc := acc;
+    go nil _ acc := acc;
+    go (a :: az) (b :: bz) acc := go az bz (f a b :: acc);
+  in reverse (go as bs nil);
+
+catMaybes : {A : Type} -> List (Maybe A) -> List A;
+catMaybes nil := nil;
+catMaybes (just h :: hs) := h :: catMaybes hs;
+catMaybes (nothing :: hs) := catMaybes hs;

--- a/Data/Tmp.juvix
+++ b/Data/Tmp.juvix
@@ -27,3 +27,6 @@ catMaybes : {A : Type} -> List (Maybe A) -> List A;
 catMaybes nil := nil;
 catMaybes (just h :: hs) := h :: catMaybes hs;
 catMaybes (nothing :: hs) := catMaybes hs;
+
+concatMap : {A B : Type} -> (A -> List B) -> List A -> List B;
+concatMap f := flatten ∘ map f;

--- a/Data/Tmp.juvix
+++ b/Data/Tmp.juvix
@@ -30,3 +30,13 @@ catMaybes (nothing :: hs) := catMaybes hs;
 
 concatMap : {A B : Type} -> (A -> List B) -> List A -> List B;
 concatMap f := flatten ∘ map f;
+
+printNatListLn : List Nat → IO;
+printNatListLn nil := printStringLn "nil";
+printNatListLn (x :: xs) :=
+  printNat x >> printString " :: " >> printNatListLn xs;
+
+--- Absolute value
+abs : Int -> Nat;
+abs (ofNat n) := n;
+abs (negSuc n) := suc n;

--- a/Data/Tree.juvix
+++ b/Data/Tree.juvix
@@ -2,7 +2,7 @@
 module Data.Tree;
 
 open import Stdlib.Prelude;
-open import Data.Showing;
+open import Data.Show;
 open import Data.Tmp;
 
 --- A ;List; of trees.
@@ -20,16 +20,16 @@ shift :
 shift n first other :=
   zipWith (++str) (first :: replicate n other);
 
-draw : {A : Type} -> Showing A -> Tree A -> List String;
+draw : {A : Type} -> Show A -> Tree A -> List String;
 
 drawForest :
-  {A : Type} -> Showing A -> Forest A -> List String;
+  {A : Type} -> Show A -> Forest A -> List String;
 
-draw {A} s@(showing show) (node v cs) :=
+draw {A} s@(show fshow) (node v cs) :=
   let
     go : Tree A -> List String;
     go := draw s;
-  in show v :: drawForest s cs;
+  in fshow v :: drawForest s cs;
 
 drawForest s nil := nil;
 drawForest s (h :: nil) :=
@@ -37,8 +37,8 @@ drawForest s (h :: nil) :=
 drawForest s (h :: hs) :=
   "|" :: shift 300 "+- " "|  " (draw s h) ++ drawForest s hs;
 
-treeToString : {A : Type} -> Showing A -> Tree A -> String;
+treeToString : {A : Type} -> Show A -> Tree A -> String;
 treeToString s := unlines ∘ draw s;
 
-forestToString : {A : Type} -> Showing A -> Forest A -> String;
+forestToString : {A : Type} -> Show A -> Forest A -> String;
 forestToString s := unlines ∘ drawForest s;

--- a/Data/Tree.juvix
+++ b/Data/Tree.juvix
@@ -1,38 +1,44 @@
+--- N-Ary trees with pretty printing.
 module Data.Tree;
 
-open import Stdlib.Prelude hiding {length};
+open import Stdlib.Prelude;
+open import Data.Showing;
+open import Data.Tmp;
 
-type BinaryTree (A : Type) :=
-  | leaf : BinaryTree A
-  | node : BinaryTree A -> A -> BinaryTree A -> BinaryTree A;
+--- A ;List; of trees.
+Forest : Type -> Type;
 
--- fold a tree in depth first order
-fold :
-  {A B : Type}
-    -> (A -> B -> B -> B)
-    -> B
-    -> BinaryTree A
-    -> B;
-fold {A} {B} f acc :=
+--- N-Ary tree.
+positive
+type Tree (A : Type) :=
+  | node : A -> Forest A -> Tree A;
+
+Forest A := List (Tree A);
+
+shift :
+  Nat -> String -> String -> List String -> List String;
+shift n first other :=
+  zipWith (++str) (first :: replicate n other);
+
+draw : {A : Type} -> Showing A -> Tree A -> List String;
+
+drawForest :
+  {A : Type} -> Showing A -> Forest A -> List String;
+
+draw {A} s@(showing show) (node v cs) :=
   let
-    go : B -> BinaryTree A -> B;
-    go acc leaf := acc;
-    go acc (node l a r) := f a (go acc l) (go acc r);
-  in go acc;
+    go : Tree A -> List String;
+    go := draw s;
+  in show v :: drawForest s cs;
 
-length : {A : Type} -> BinaryTree A -> Nat;
-length :=
-  fold
-    λ {
-      | _ l r := 1 + l + r
-    }
-    0;
+drawForest s nil := nil;
+drawForest s (h :: nil) :=
+  "|" :: shift 300 "`- " "   " (draw s h);
+drawForest s (h :: hs) :=
+  "|" :: shift 300 "+- " "|  " (draw s h) ++ drawForest s hs;
 
-to-list : {A : Type} -> BinaryTree A -> List A;
-to-list :=
-  fold
-    λ {
-      | e ls rs := e :: ls ++ rs
-    }
-    nil;
+treeToString : {A : Type} -> Showing A -> Tree A -> String;
+treeToString s := unlines ∘ draw s;
 
+forestToString : {A : Type} -> Showing A -> Forest A -> String;
+forestToString s := unlines ∘ drawForest s;

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build/Map: $(wildcard ./**/*.juvix) deps
 	@mkdir -p build/
 	juvix compile Data/Map.juvix -o build/Map
 
-build/AVL: $(wildcard ./**/*.juvix) deps
+build/AVL: $(shell find . -name '*.juvix') deps
 	@mkdir -p build/
 	juvix compile Data/Set/AVL.juvix -o build/AVL
 

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,15 @@ build/Map: $(wildcard ./**/*.juvix) deps
 	@mkdir -p build/
 	juvix compile Data/Map.juvix -o build/Map
 
+build/AVL: $(wildcard ./**/*.juvix) deps
+	@mkdir -p build/
+	juvix compile Data/Set/AVL.juvix -o build/AVL
+
 .PHONY : test
-test: build/Set build/Map
+test: build/Set build/Map build/AVL
 	./build/Set
 	./build/Map
+	./build/AVL
 
 .PHONY: clean-build
 clean-build:


### PR DESCRIPTION
This PR adds an efficient implementation of Sets based on AVL trees.
The currently supported operations are
- `fromList`
- `insert`
- `delete`
- `member?`
- `lookupMin`
- `lookupMax`
- and fancy pretty printing